### PR TITLE
Alteração Feriado Municipal de Vacaria

### DIFF
--- a/dados/feriados/municipal/csv/2023.csv
+++ b/dados/feriados/municipal/csv/2023.csv
@@ -6479,7 +6479,7 @@
 10/09/2023,"Feriado Municipal",MUNICIPAL,"",RS,Tuparendi 
 31/10/2023,"Feriado Municipal",MUNICIPAL,"",RS,Tuparendi 
 26/07/2023,"Feriado Municipal",MUNICIPAL,"",RS,Uruguaiana 
-08/09/2023,"Feriado Municipal",MUNICIPAL,"",RS,Vacaria 
+08/12/2023,"Feriado Municipal",MUNICIPAL,"",RS,Vacaria
 25/07/2023,"Feriado Municipal",MUNICIPAL,"",RS,Vale do Sol 
 10/11/2023,"Feriado Municipal",MUNICIPAL,"",RS,Vale do Sol 
 13/06/2023,"Dia de Santo Antônio",MUNICIPAL,"",RS,Vale Verde 

--- a/dados/feriados/municipal/csv/2024.csv
+++ b/dados/feriados/municipal/csv/2024.csv
@@ -6466,7 +6466,7 @@
 10/09/2024,"Feriado Municipal",MUNICIPAL,"",RS,Tuparendi 
 31/10/2024,"Feriado Municipal",MUNICIPAL,"",RS,Tuparendi 
 26/07/2024,"Feriado Municipal",MUNICIPAL,"",RS,Uruguaiana 
-08/09/2024,"Feriado Municipal",MUNICIPAL,"",RS,Vacaria 
+08/12/2024,"Feriado Municipal",MUNICIPAL,"",RS,Vacaria
 25/07/2024,"Feriado Municipal",MUNICIPAL,"",RS,Vale do Sol 
 10/11/2024,"Feriado Municipal",MUNICIPAL,"",RS,Vale do Sol 
 13/06/2024,"Dia de Santo Antônio",MUNICIPAL,"",RS,Vale Verde 

--- a/dados/feriados/municipal/csv/2025.csv
+++ b/dados/feriados/municipal/csv/2025.csv
@@ -6480,7 +6480,7 @@
 10/09/2025,"Feriado Municipal",MUNICIPAL,"",RS,Tuparendi 
 31/10/2025,"Feriado Municipal",MUNICIPAL,"",RS,Tuparendi 
 26/07/2025,"Feriado Municipal",MUNICIPAL,"",RS,Uruguaiana 
-08/09/2025,"Feriado Municipal",MUNICIPAL,"",RS,Vacaria 
+08/12/2025,"Feriado Municipal",MUNICIPAL,"",RS,Vacaria
 25/07/2025,"Feriado Municipal",MUNICIPAL,"",RS,Vale do Sol 
 10/11/2025,"Feriado Municipal",MUNICIPAL,"",RS,Vale do Sol 
 13/06/2025,"Dia de Santo Antônio",MUNICIPAL,"",RS,Vale Verde 

--- a/dados/feriados/municipal/json/2023.json
+++ b/dados/feriados/municipal/json/2023.json
@@ -51848,7 +51848,7 @@
     "municipio": "Uruguaiana"
   },
   {
-    "data": "08/09/2023",
+    "data": "08/12/2023",
     "nome": "Feriado Municipal",
     "tipo": "MUNICIPAL",
     "descricao": "",

--- a/dados/feriados/municipal/json/2024.json
+++ b/dados/feriados/municipal/json/2024.json
@@ -51744,7 +51744,7 @@
     "municipio": "Uruguaiana"
   },
   {
-    "data": "08/09/2024",
+    "data": "08/12/2024",
     "nome": "Feriado Municipal",
     "tipo": "MUNICIPAL",
     "descricao": "",

--- a/dados/feriados/municipal/json/2025.json
+++ b/dados/feriados/municipal/json/2025.json
@@ -51856,7 +51856,7 @@
     "municipio": "Uruguaiana"
   },
   {
-    "data": "08/09/2025",
+    "data": "08/12/2025",
     "nome": "Feriado Municipal",
     "tipo": "MUNICIPAL",
     "descricao": "",

--- a/dados/feriados/municipal/sql/2023.sql
+++ b/dados/feriados/municipal/sql/2023.sql
@@ -6479,7 +6479,7 @@ INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('09/05
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('10/09/2023', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Tuparendi');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('31/10/2023', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Tuparendi');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('26/07/2023', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Uruguaiana');
-INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('08/09/2023', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vacaria');
+INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('08/12/2023', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vacaria');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('25/07/2023', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vale do Sol');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('10/11/2023', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vale do Sol');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('13/06/2023', 'Dia de Santo Antônio', 'MUNICIPAL', '', 'RS', 'Vale Verde');

--- a/dados/feriados/municipal/sql/2024.sql
+++ b/dados/feriados/municipal/sql/2024.sql
@@ -6466,7 +6466,7 @@ INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('09/05
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('10/09/2024', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Tuparendi');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('31/10/2024', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Tuparendi');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('26/07/2024', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Uruguaiana');
-INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('08/09/2024', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vacaria');
+INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('08/12/2024', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vacaria');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('25/07/2024', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vale do Sol');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('10/11/2024', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vale do Sol');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('13/06/2024', 'Dia de Santo Antônio', 'MUNICIPAL', '', 'RS', 'Vale Verde');

--- a/dados/feriados/municipal/sql/2025.sql
+++ b/dados/feriados/municipal/sql/2025.sql
@@ -6480,7 +6480,7 @@ INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('09/05
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('10/09/2025', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Tuparendi');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('31/10/2025', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Tuparendi');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('26/07/2025', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Uruguaiana');
-INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('08/09/2025', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vacaria');
+INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('08/12/2025', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vacaria');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('25/07/2025', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vale do Sol');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('10/11/2025', 'Feriado Municipal', 'MUNICIPAL', '', 'RS', 'Vale do Sol');
 INSERT INTO feriados (data, nome, tipo, descricao, uf, municipio) VALUES ('13/06/2025', 'Dia de Santo Antônio', 'MUNICIPAL', '', 'RS', 'Vale Verde');


### PR DESCRIPTION
O feriado municipal de Vacaria foi alterado para o dia 08/12, a dia da padroeira é dia 08/09, porém o feriado é dia 08/12, devido a um pedido do comércio local.

Conforme link abaixo:
https://vacaria.rs.gov.br/noticia/novas-datas-dos-feriados-comemorativos-do-municipio